### PR TITLE
Fix python_version format

### DIFF
--- a/fidelisnetwork.json
+++ b/fidelisnetwork.json
@@ -18,10 +18,7 @@
     ],
     "logo": "logo_fidelisnetwork.svg",
     "logo_dark": "logo_fidelisnetwork_dark.svg",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "configuration": {
         "host_url": {

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)